### PR TITLE
Added instructions to run in a Github codespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _streamlit_app/.env
 *.pyc
 *.log
 .DS_Store
+.env

--- a/README.md
+++ b/README.md
@@ -51,6 +51,25 @@
 > [!Note]
 > The app logs user interactions to your local computer or virtual machine to a file named `app.log`. If you do not want to have analytics, simply comment out the function call in the code. 
 
+**Run the app in a Github Codespace**
+- This will enable you to develop and run the app in a cloud-hosted development workspace, using [GitHub Codespaces](https://docs.github.com/en/codespaces/overview). 
+- Some benefits: No need for any local installation, you can do anything right from your Web Browser. Ah, you get quite some free hours with your GitHub account, so this should not be expensive at all. 
+- Create a GitHub codespace on this repository by clicking `Code > Codespaces > Create codespace on main`
+- Wait until the codespace is started. You'll get a new url like 'https://buenzli-kehrwoche-w8wrwwqgarq0815.github.dev/'
+- Install the project requirements from the terminal: `pip install -r requirements.txt`
+- Install spacy language model: `python -m spacy download de_core_news_sm`
+- Create an `.env` file and input your API keys:
+```
+    OPENAI_API_KEY=sk-...
+    ANTHROPIC_API_KEY=sk-...
+    MISTRAL_API_KEY=KGT...
+```
+- Alternativly, create Repository Secrets on GitHub, which will get available for your codespaces automatically when starting up (only if you are a repo owner / using your own fork)
+- Start app (change cwd first): `cd _streamlit_app && python -m streamlit run ./sprache-vereinfachen.py`
+- Codespaces auto-proxies and forwards Port 8501 to something like `https://buenzli-kehrwoche-w8wrwwqgarq0815-8501.app.github.dev/`
+- In case you don't like coding in your browser, you can also use a local VSCode IDE and connect to the remote Codespace .
+
+
 ## Project information
 **Institutional communication is often overly complicated and hard to understand.**
 


### PR DESCRIPTION
This pull request introduces instructions on how to run the application in a GitHub Codespace. The changes provide a step-by-step guide on setting up the codespace, installing project requirements, and starting the application.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R54-R72): Added instructions on how to run the app in a GitHub Codespace. The instructions cover creating a codespace, installing project requirements, setting up API keys, and starting the app.